### PR TITLE
fix: minor fixes & code cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,9 @@ If you don't want to rename/move files, use the option `rename_files`, for insta
 api.nvim_set_keymap('n', '<Leader>h', ':lua require("replacer").run({ rename_files = false })<cr>', { silent = true })
 ```
 
+> __Warning__  
+> Do not use `rg --trim` for your vimgrep options (or in fzf.vim's or telescope's respective settings). Doing so will result in a removal of indentation when using replacer.nvim.
+
 ## Installation
 
 ### [vim-plug](https://github.com/junegunn/vim-plug#readme)

--- a/lua/replacer/init.lua
+++ b/lua/replacer/init.lua
@@ -121,6 +121,10 @@ local function save(qf_bufnr, qf_items, opts)
                     api.nvim_buf_delete(item.bufnr, {})
                 end
 
+                -- ensure destination directory exists
+                vim.fn.mkdir(basename(dest_file), "p")
+
+                ---@diagnostic disable-next-line: param-type-mismatch wrong annotation information when using neodeiv + lua-lsp
                 local exitCode = vim.fn.rename(source_file, dest_file)
                 if exitCode ~= 0 then
                     local msg = string.format('Failed to rename %s to %s: %s', source_file, dest_file)

--- a/lua/replacer/init.lua
+++ b/lua/replacer/init.lua
@@ -194,10 +194,6 @@ function M.run(opts)
     vim.bo.buftype = 'acwrite'
     vim.bo.filetype = 'replacer'
     vim.bo.formatoptions = '' -- to not autowrap lines, breaking filenames
-
-    -- add keymaps
-    vim.keymap.set("n", "q", vim.cmd.close, { desc = "Abort replacements", buffer = true, nowait = true })
-    vim.keymap.set("n", "<CR>", vim.cmd.write, { desc = "Confirm replacements", buffer = true, nowait = true })
 end
 
 return M;

--- a/lua/replacer/init.lua
+++ b/lua/replacer/init.lua
@@ -186,9 +186,11 @@ function M.run(opts)
     api.nvim_buf_set_name(0, 'replacer://replacer')
     api.nvim_win_set_cursor(0, {1, 0})
 
-    vim.wo.cursorcolumn = false
-    vim.wo.number = false
-    vim.wo.relativenumber = false
+    vim.opt_local.cursorcolumn = false
+    vim.opt_local.number = false
+    vim.opt_local.wrap = false
+    vim.opt_local.relativenumber = false
+    vim.opt_local.number = false
     vim.bo.buftype = 'acwrite'
     vim.bo.filetype = 'replacer'
     vim.bo.formatoptions = '' -- to not autowrap lines, breaking filenames

--- a/lua/replacer/init.lua
+++ b/lua/replacer/init.lua
@@ -186,6 +186,7 @@ function M.run(opts)
     vim.wo.relativenumber = false
     vim.bo.buftype = 'acwrite'
     vim.bo.filetype = 'replacer'
+    vim.bo.formatoptions = '' -- to not autowrap lines, breaking filenames
 end
 
 return M;

--- a/lua/replacer/init.lua
+++ b/lua/replacer/init.lua
@@ -67,11 +67,6 @@ local function save(qf_bufnr, qf_items, opts)
                 ::skip_to_next_part::
             end
 
-            -- add indentation to the line back to the line, since it's not
-            -- displayed in the quickfix window and otherwise missing there
-            local leadingWhitespace = current_line:match("^%s+")
-            if leadingWhitespace then line = leadingWhitespace .. line end
-
             if current_line ~= line then lines[item.lnum] = line end
 
             ::skip_to_next_file::

--- a/lua/replacer/init.lua
+++ b/lua/replacer/init.lua
@@ -184,7 +184,7 @@ function M.run(opts)
         end
     })
 
-    api.nvim_buf_set_name(0, 'replacer://1')
+    api.nvim_buf_set_name(0, 'replacer://replacer')
     api.nvim_win_set_cursor(0, {1, 0})
 
     vim.wo.cursorcolumn = false

--- a/lua/replacer/init.lua
+++ b/lua/replacer/init.lua
@@ -184,7 +184,7 @@ function M.run(opts)
         end
     })
 
-    api.nvim_buf_set_name(0, 'Quickfix: Replacer')
+    api.nvim_buf_set_name(0, 'replacer://1')
     api.nvim_win_set_cursor(0, {1, 0})
 
     vim.wo.cursorcolumn = false

--- a/lua/replacer/init.lua
+++ b/lua/replacer/init.lua
@@ -126,9 +126,9 @@ local function save(qf_bufnr, qf_items, opts)
                     api.nvim_buf_delete(item.bufnr, {})
                 end
 
-                local success, errormsg = os.rename(source_file, dest_file)
-                if not success then
-                    local msg = string.format('Failed to rename %s to %s: %s', source_file, dest_file, errormsg)
+                local exitCode = vim.fn.rename(source_file, dest_file)
+                if exitCode ~= 0 then
+                    local msg = string.format('Failed to rename %s to %s: %s', source_file, dest_file)
                     vim.notify(msg, vim.log.levels.ERROR)
                 end
 

--- a/lua/replacer/init.lua
+++ b/lua/replacer/init.lua
@@ -14,16 +14,10 @@ local function basename(path)
     return table.concat(chunks, "/")
 end
 
-function table.empty(self)
-    for _, _ in pairs(self) do return false end
-
-    return true
-end
 
 local function delete_empty_folder(file)
     local folder = basename(file)
-
-    if table.empty(vim.fn.readdir(folder)) then vim.fn.delete(folder, "d") end
+    if vim.tbl_isempty(vim.fn.readdir(folder)) then vim.fn.delete(folder, "d") end
 end
 
 local function cleanup(bufnr)

--- a/lua/replacer/init.lua
+++ b/lua/replacer/init.lua
@@ -70,7 +70,7 @@ local function save(qf_bufnr, qf_items, opts)
             -- add indentation to the line back to the line, since it's not
             -- displayed in the quickfix window and otherwise missing there
             local leadingWhitespace = current_line:match("^%s+")
-            line = leadingWhitespace .. line
+            if leadingWhitespace then line = leadingWhitespace .. line end
 
             if current_line ~= line then lines[item.lnum] = line end
 

--- a/lua/replacer/init.lua
+++ b/lua/replacer/init.lua
@@ -67,6 +67,11 @@ local function save(qf_bufnr, qf_items, opts)
                 ::skip_to_next_part::
             end
 
+            -- add indentation to the line back to the line, since it's not
+            -- displayed in the quickfix window and otherwise missing there
+            local leadingWhitespace = current_line:match("^%s+")
+            line = leadingWhitespace .. line
+
             if current_line ~= line then lines[item.lnum] = line end
 
             ::skip_to_next_file::

--- a/lua/replacer/init.lua
+++ b/lua/replacer/init.lua
@@ -192,6 +192,10 @@ function M.run(opts)
     vim.bo.buftype = 'acwrite'
     vim.bo.filetype = 'replacer'
     vim.bo.formatoptions = '' -- to not autowrap lines, breaking filenames
+
+    -- add keymaps
+    vim.keymap.set("n", "q", vim.cmd.close, { desc = "Abort replacements", buffer = true, nowait = true })
+    vim.keymap.set("n", "<CR>", vim.cmd.write, { desc = "Confirm replacements", buffer = true, nowait = true })
 end
 
 return M;

--- a/lua/replacer/init.lua
+++ b/lua/replacer/init.lua
@@ -1,15 +1,17 @@
 local autocmd = vim.api.nvim_create_autocmd
 local api = vim.api
 
-local replacer = {}
+local M = {}
 
-function basename(path)
-    chunks = vim.fn.split(path, "/")
-    size = vim.tbl_count(chunks)
+local function basename(path)
+    local chunks = vim.fn.split(path, "/")
+    local size = vim.tbl_count(chunks)
 
     if size == 1 then return nil end
 
-    return vim.fn.join(vim.fn.remove(chunks, 0, -2), "/")
+    table.remove(chunks)
+    table.remove(chunks)
+    return table.concat(chunks, "/")
 end
 
 function table.empty(self)
@@ -18,13 +20,13 @@ function table.empty(self)
     return true
 end
 
-function delete_empty_folder(file)
+local function delete_empty_folder(file)
     local folder = basename(file)
 
     if table.empty(vim.fn.readdir(folder)) then vim.fn.delete(folder, "d") end
 end
 
-function cleanup(bufnr)
+local function cleanup(bufnr)
     api.nvim_buf_delete(bufnr, {force = true})
     -- cleanup qf list
     vim.fn.setqflist({}, "r")
@@ -32,10 +34,8 @@ function cleanup(bufnr)
     vim.cmd('edit')
 end
 
-function save(qf_bufnr, qf_items, opts)
+local function save(qf_bufnr, qf_items, opts)
     local rename_files = opts['rename_files']
-
-    local qf_win_nr = vim.fn.bufwinid(qf_bufnr)
 
     vim.bo[qf_bufnr].modified = false
 
@@ -44,7 +44,7 @@ function save(qf_bufnr, qf_items, opts)
     local unique_files = {}
 
     -- get every unique file
-    for _index, item in pairs(qf_items) do
+    for _, item in pairs(qf_items) do
         unique_files[vim.fn.bufname(item.bufnr)] = true
     end
 
@@ -81,8 +81,7 @@ function save(qf_bufnr, qf_items, opts)
         local result = vim.fn.writefile(lines, current_file, "S")
 
         if result < 0 then
-            error(string.format('Something went wrong writing file %s',
-                                current_file))
+            vim.notify(string.format('Something went wrong writing file %s', current_file), vim.log.levels.ERROR)
             cleanup(qf_bufnr)
             return
         end
@@ -123,24 +122,21 @@ function save(qf_bufnr, qf_items, opts)
             if source_file ~= "" and vim.fn.filereadable(source_file) then
                 renamed_files[item.bufnr] = true
 
-                local dest_folder = vim.fn.mkdir(basename(dest_file), "p")
-
                 -- delete open buffer that's not visible
                 if source_is_loaded and source_win_id == -1 then
                     api.nvim_buf_delete(item.bufnr, {})
                 end
 
-                if vim.fn.rename(source_file, dest_file) ~= 0 then
-                    error(string.format('Failed to rename %s to %s',
-                                        source_file, dest_file))
+                local success, errormsg = os.rename(source_file, dest_file)
+                if not success then
+                    local msg = string.format('Failed to rename %s to %s: %s', source_file, dest_file, errormsg)
+                    vim.notify(msg, vim.log.levels.ERROR)
                 end
 
                 -- update visible buffer to point to the new file
                 if source_win_id ~= -1 then
                     api.nvim_set_current_win(source_win_id)
-
                     api.nvim_command("edit! " .. dest_file)
-
                     api.nvim_buf_delete(item.bufnr, {})
                 end
 
@@ -152,30 +148,32 @@ function save(qf_bufnr, qf_items, opts)
     end
 
     cleanup(qf_bufnr)
-    return
 end
 
-function replacer.run(opts)
-    local opts = opts or {}
+function M.run(opts)
+	if #vim.fn.getqflist() == 0 then
+		vim.notify('Quickfix List empty.', vim.log.levels.WARN)
+		return
+	end
+
+    opts = opts or {}
     local rename_files = true
 
     if opts['rename_files'] == false then rename_files = false end
 
-    if vim.bo.filetype ~= "qf" then
-        error('Current buffer is not a quickfix list')
-        return
-    end
+    -- open quickfix list, if it is not open
+    if vim.bo.filetype ~= "qf" then vim.cmd.copen() end
 
     local qf_bufnr = vim.fn.bufnr()
     local qf_items = vim.fn.getqflist()
 
     vim.bo.modifiable = true
 
-    api.nvim_buf_set_lines(qf_bufnr, 0, -1, false, {})
+    api.nvim_buf_set_lines(0, 0, -1, false, {})
 
     for i, item in pairs(qf_items) do
         local line = vim.fn.bufname(item.bufnr) .. ':' .. item.text
-        api.nvim_buf_set_lines(qf_bufnr, i - 1, i - 1, false, {line})
+        api.nvim_buf_set_lines(0, i - 1, i - 1, false, {line})
     end
 
     autocmd('BufWriteCmd', {
@@ -186,7 +184,7 @@ function replacer.run(opts)
         end
     })
 
-    api.nvim_buf_set_name(qf_bufnr, 'replacer://' .. 1)
+    api.nvim_buf_set_name(0, 'Quickfix: Replacer')
     api.nvim_win_set_cursor(0, {1, 0})
 
     vim.wo.cursorcolumn = false
@@ -196,4 +194,4 @@ function replacer.run(opts)
     vim.bo.filetype = 'replacer'
 end
 
-return replacer;
+return M;


### PR DESCRIPTION
a bunch of small stuff:
- fixed a dozen diagnostic messages from the lua LSP, e.g. removing unused code
- switched from vimscript to lua API here and there
- uses more recent nvim API, e.g. vim.notify (which makes this plugin compatible with newer plugins like nvim-notify)
- buffername is now correctly set
- if the command is not called in a quickfix buffer, it opens the quickfix window instead of failing
- if the quickfix window is empty, it will abort the run instead of working in an empty quickfix list
- renamed the module from `replacer` to `M`, since that is the common convention for lua plugins